### PR TITLE
Remove conflict to symfony/polyfill-mbstring

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,9 +14,6 @@
         "php": "^8.0",
         "symfony/framework-bundle": "^5.4 || ^6.0"
     },
-    "conflict": {
-        "symfony/polyfill-mbstring": "1.22.0"
-    },
     "require-dev": {
         "phpunit/phpunit": "^9.5",
         "vimeo/psalm": "^4.23"


### PR DESCRIPTION
I don't know why the conflict existed, and there is no sound track about it on git/github but the conflict forbids using the standard composer mechanism to replace the polyfill and use an extension instead.

```json
{
    "replace": {
        "symfony/polyfill-mbstring": "*"
    }
}
```

See the https://github.com/SyliusLabs/PolyfillSymfonySecurity/pull/6